### PR TITLE
add reindex btn in admin panel

### DIFF
--- a/app/jobs/regular/elasticsearch_jobs.rb
+++ b/app/jobs/regular/elasticsearch_jobs.rb
@@ -25,4 +25,29 @@ module Jobs
       DiscourseElasticsearch::ElasticsearchHelper.index_post(args[:post_id], args[:discourse_event])
     end
   end
+
+  class ReindexAllPostsToElasticsearch < Jobs::Base
+    def execute(args)
+      return unless SiteSetting.elasticsearch_enabled?
+      
+      begin
+        # Load the rake task methods  
+        load File.expand_path("../../../lib/tasks/discourse_elasticsearch.rake", __dir__)
+        
+        Rails.logger.info("Starting Elasticsearch reindex job")
+        
+        elasticsearch_configure_users
+        elasticsearch_configure_posts
+        elasticsearch_configure_tags
+        elasticsearch_configure_map
+        elasticsearch_reindex_posts
+        
+        Rails.logger.info("Completed Elasticsearch reindex job successfully")
+      rescue => e
+        Rails.logger.error("Elasticsearch reindex job failed: #{e.message}")
+        Rails.logger.error(e.backtrace.join("\n"))
+        raise e
+      end
+    end
+  end
 end

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-elasticsearch.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-elasticsearch.js
@@ -1,0 +1,34 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export default class AdminPluginsDiscourseElasticsearchController extends Controller {
+  @tracked reindexComplete = false;
+  @tracked reindexError = null;
+
+  @action
+  reindexPosts() {
+    this.reindexComplete = false;
+    this.reindexError = null;
+
+    ajax("/discourse-elasticsearch/admin/reindex", {
+      type: "POST",
+    })
+      .then((result) => {
+        this.reindexComplete = true;
+        if (result.message) {
+          console.log("Reindex result:", result.message);
+        }
+      })
+      .catch((error) => {
+        const errorMessage = error.jqXHR?.responseJSON?.errors?.[0] || 
+                           error.responseJSON?.errors?.[0] || 
+                           error.message || 
+                           "Unknown error occurred";
+        this.reindexError = errorMessage;
+        popupAjaxError(error);
+      });
+  }
+}

--- a/assets/javascripts/discourse/discourse-elasticsearch-route-map.js
+++ b/assets/javascripts/discourse/discourse-elasticsearch-route-map.js
@@ -1,0 +1,7 @@
+export default {
+  resource: "admin.adminPlugins",
+  path: "/plugins",
+  map() {
+    this.route("discourse-elasticsearch");
+  },
+};

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-elasticsearch.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-elasticsearch.hbs
@@ -1,0 +1,29 @@
+<div class="admin-elasticsearch">
+  <h2>{{i18n "discourse_elasticsearch.admin.title"}}</h2>
+  
+  <div class="admin-elasticsearch-section">
+    <h3>{{i18n "discourse_elasticsearch.admin.reindex_section"}}</h3>
+    <p>{{i18n "discourse_elasticsearch.admin.reindex_description"}}</p>
+    
+    {{#if this.reindexComplete}}
+      <div class="alert alert-success">
+        {{i18n "discourse_elasticsearch.admin.reindex_complete"}}
+      </div>
+    {{/if}}
+    
+    {{#if this.reindexError}}
+      <div class="alert alert-error">
+        {{i18n "discourse_elasticsearch.admin.reindex_error"}} {{this.reindexError}}
+      </div>
+    {{/if}}
+    
+    <div class="buttons">
+      <DButton
+        @label="discourse_elasticsearch.admin.reindex_posts"
+        @action={{action "reindexPosts"}}
+        @icon="sync"
+        @class="btn-primary"
+      />
+    </div>
+  </div>
+</div>

--- a/assets/stylesheets/admin-elasticsearch.scss
+++ b/assets/stylesheets/admin-elasticsearch.scss
@@ -1,0 +1,53 @@
+.admin-elasticsearch {
+  margin: 20px;
+
+  h2 {
+    margin-bottom: 20px;
+  }
+
+  .admin-elasticsearch-section {
+    background: var(--primary-very-low);
+    padding: 20px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+
+    h3 {
+      margin-bottom: 10px;
+    }
+
+    p {
+      margin-bottom: 20px;
+      color: var(--primary-medium);
+    }
+  }
+
+  .reindex-status {
+    display: flex;
+    align-items: center;
+    margin-bottom: 20px;
+    
+    .spinner {
+      margin-right: 10px;
+    }
+  }
+
+  .alert {
+    margin-bottom: 20px;
+    padding: 12px;
+    border-radius: 4px;
+
+    &.alert-success {
+      background-color: var(--success-low);
+      color: var(--success);
+    }
+
+    &.alert-error {
+      background-color: var(--danger-low);
+      color: var(--danger);
+    }
+  }
+
+  .buttons {
+    margin-top: 20px;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,10 @@
+en:
+  js:
+    discourse_elasticsearch:
+      admin:
+        title: "Elasticsearch"
+        reindex_section: "Reindex Operations"
+        reindex_description: "Reindex all posts to Elasticsearch. This operation runs in the background and may take some time depending on the number of posts."
+        reindex_posts: "Start Reindex Job"
+        reindex_complete: "Reindex job started successfully! Check the logs for progress."
+        reindex_error: "Error during reindexing:"

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,6 +12,7 @@ gem "elasticsearch", "8.4.0"
 register_asset "stylesheets/variables.scss"
 register_asset "stylesheets/elasticsearch-base.scss"
 register_asset "stylesheets/elasticsearch-layout.scss"
+register_asset "stylesheets/admin-elasticsearch.scss", :admin
 register_asset "lib/typehead.bundle.js"
 
 enabled_site_setting :elasticsearch_enabled
@@ -44,10 +45,36 @@ after_initialize do
     end
   end
 
-  DiscourseElasticsearch::Engine.routes.draw { get "/list" => "actions#list" }
+  require_dependency "admin/admin_controller"
+  class DiscourseElasticsearch::AdminController < ::Admin::AdminController
+    requires_plugin PLUGIN_NAME
+
+    def reindex
+      unless SiteSetting.elasticsearch_enabled?
+        return render json: { errors: ["Elasticsearch is not enabled"] }, status: 422
+      end
+
+      begin
+        Jobs.enqueue(:reindex_all_posts_to_elasticsearch)
+        render json: success_json.merge(message: "Reindexing job has been queued successfully")
+      rescue => e
+        Rails.logger.error("Failed to enqueue reindex job: #{e.message}")
+        render json: { errors: ["Failed to start reindex job: #{e.message}"] }, status: 500
+      end
+    end
+  end
+
+  DiscourseElasticsearch::Engine.routes.draw do
+    get "/list" => "actions#list"
+    post "/admin/reindex" => "admin#reindex", constraints: StaffConstraint.new
+  end
+
+  # Add admin route
+  add_admin_route 'discourse_elasticsearch.admin.title', 'discourse-elasticsearch'
 
   Discourse::Application.routes.append do
     mount ::DiscourseElasticsearch::Engine, at: "/discourse-elasticsearch"
+    get '/admin/plugins/discourse-elasticsearch' => 'admin/plugins#index', constraints: StaffConstraint.new
   end
 
   %i[user_created user_updated].each do |discourse_event|


### PR DESCRIPTION
* Added a new admin page
* Create an endpoint for `/admin/reindex` and register its route. 

Note: this doesnt show the progress of the indexing. need to check logs for that. 

<img width="1414" alt="Screenshot 2025-06-18 at 11 56 34 AM" src="https://github.com/user-attachments/assets/c1d3e3f8-a637-43ec-91a1-89a4b6e85cf3" />

`/admin/plugins/discourse-elasticsearch`